### PR TITLE
feat: enable storing drawings to be used later

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,13 +14,18 @@ import Rectangle from "./Rectangle";
 import Ellipse from "./Ellipse";
 import Line from "./Line";
 import Pencil from "./Pencil";
+import { saveShapesToMemory } from "./utils";
 
 let originalCursorPosition: { x: number; y: number };
 let cursorPosition: { x: number; y: number };
 
 let pencilStates: { x: number; y: number }[] = [];
 
-function App() {
+type Props = {
+  savedShapes: []
+}
+
+function App(props: Props) {
   const [selectedShape, setSelectedShape] = useState<
     "pencil" | "rectangle" | "ellipse" | "line"
   >("pencil");
@@ -62,7 +67,17 @@ function App() {
           details: (typeof cursorPosition)[];
         }
     )[]
-  >([]);
+  >(props.savedShapes);
+
+  /**
+   * Store the shape after each draw,
+   * to be retrieved later.
+   */
+  useEffect(() => {
+    saveShapesToMemory<typeof shapes>(shapes)
+  }, [shapes]);
+
+
 
   /**
    * maintaining popped states so that we can allow user to redo stuff
@@ -403,6 +418,14 @@ function App() {
     },
     [draw]
   );
+
+  /**
+   * Now draw the shapes, that are retreived from last session.
+   * We strictly needs to run it once.
+   */
+  useEffect(() => {
+    drawEverything(props.savedShapes);
+  }, [props.savedShapes, drawEverything]);
 
   const undoShape = useCallback(() => {
     let redrawnShapes: typeof shapes = [];

--- a/src/Pencil.tsx
+++ b/src/Pencil.tsx
@@ -1,4 +1,3 @@
-import pen from "./pen.png";
 import { TbPencil } from "react-icons/tb";
 
 function Pencil(props: {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,8 +2,10 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
+import { retrieveShapesFromMemory } from "./utils";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
-root.render(<App />);
+
+root.render(<App savedShapes={retrieveShapesFromMemory()} />);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,14 @@
+export function saveShapesToMemory<T>(shapes: T) {
+  localStorage.setItem("shapes", JSON.stringify(shapes));
+}
+
+export function retrieveShapesFromMemory() {
+  /**
+   * This is coming from user's previous session.
+   */
+  try {
+    return JSON.parse(localStorage.getItem("shapes") || "");
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Problem
As a user, if I close the app after drawing some stuff, I lose the drawings.

## Solution
Storing the drawings (`shapes`) in `localstorage` to be retrieved later for initial rendering.


## After
![rec](https://github.com/BigChocoMonster/whiteboarding/assets/11800498/67e7e57e-1b10-4155-a906-229e30b4b0b8)
